### PR TITLE
[Tests-Only]Add k6 test to restore large number of files from trashbin

### DIFF
--- a/src/k6/src/test/issue/github/core/38265/create-delete-files.js
+++ b/src/k6/src/test/issue/github/core/38265/create-delete-files.js
@@ -1,0 +1,55 @@
+import http from 'k6/http';
+import encoding from 'k6/encoding';
+import { check } from 'k6';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.0.0/index.js';
+
+// need to specify host and path
+const host = ''; // http://localhost';
+const path = ''; //core
+
+export let options = {
+    iterations: 200000,
+    duration: '1000m',
+    vus: 10,
+};
+
+const createFile = url => {
+    const body = 'some content';
+    const headers = {
+        'Authorization': 'Basic ' + encoding.b64encode('admin:admin'),
+        'Content-Type': 'application/x-www-form-urlencoded',
+    };
+
+    const response = http.put(url, body, { headers: headers });
+    if (response.status === 201 || 204) {
+    } else {
+        console.log('Error while creating');
+        console.log(response.status);
+        console.log(response.body);
+    }
+    check(response, {
+        'status is 201': (r) => r.status === 201 || 204,
+    });
+};
+
+const deleteFile = (url) => {
+    const headers = {
+        'Authorization': 'Basic ' + encoding.b64encode('admin:admin'),
+    };
+    const response = http.request('DELETE', url, undefined, { headers: headers });
+    if (response.status === 204) {
+    } else {
+        console.log('Error while deleting');
+        console.log(response.status);
+        console.log(response.body);
+    }
+    check(response, {
+        'status is 204': (r) => r.status === 204,
+    });
+};
+export default function () {
+    const fileName = `${uuidv4()}.txt`;
+    const url = `${host}/${path}/remote.php/webdav/${fileName}`;
+    createFile(url);
+    deleteFile(url);
+}

--- a/src/k6/src/test/issue/github/core/38265/restore-files.js
+++ b/src/k6/src/test/issue/github/core/38265/restore-files.js
@@ -1,0 +1,126 @@
+// Restore files
+import http from 'k6/http';
+import encoding from 'k6/encoding';
+import { check, sleep } from 'k6';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.0.0/index.js';
+
+// need to specify host and path
+const host = ''; // http://localhost';
+const path = ''; //core
+
+// variables
+const vus = 10;
+const iterations = 20000; // iteration per vu
+const chunkingSize = 20000;
+const maxDuration = '6000m';
+
+export let options = {
+    scenarios: {
+        restore: {
+            executor: 'per-vu-iterations',
+            vus: vus,
+            iterations: iterations,
+            maxDuration: maxDuration,
+        },
+    },
+};
+
+// This function is used to chunk a large array into a group of smaller arrays
+const chunkArray = (array, size) => {
+    let result = [];
+    for (let i = 0; i < array.length; i += size) {
+        let chunk = array.slice(i, i + size);
+        result.push(chunk);
+    }
+    return result;
+};
+
+// returns a chunked array of file id of files in trashbin
+export function setup() {
+    let fileIds = [];
+    const propfindHeader = {
+        'Authorization': 'Basic ' + encoding.b64encode('admin:admin'),
+    };
+    const propfindUrl = `${host}/${path}/remote.php/dav/trash-bin/admin`;
+    const propfindBody = '<?xml version="1.0"?>\n' +
+        '<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n' +
+        '    <!-- retrieve the file\'s id -->\n' +
+        '    <d:prop><oc:trashbin-original-filename /></d:prop>\n' +
+        '</d:propfind>';
+    try {
+        const propfindResponse = http.request('PROPFIND', propfindUrl, propfindBody, {
+            headers: propfindHeader,
+            timeout: 180000,
+        });
+        // extracting file id from the response
+        const regex = /<d:href>\/core1\/remote\.php\/dav\/trash-bin\/admin\/(?<id>\d+)<\/d:href>/gm;
+        let m;
+        while ((m = regex.exec(JSON.stringify(propfindResponse))) !== null) {
+            if (m.index === regex.lastIndex) {
+                regex.lastIndex++;
+            }
+            fileIds.push(m[1]);
+        }
+    } catch (e) {
+        console.log(e);
+    }
+    return chunkArray(fileIds, chunkingSize);
+}
+
+const restoreFile = fileId => {
+    const fileName = `${uuidv4()}.txt`;
+    const headers = {
+        'Overwrite': 'F',
+        'Destination': `${host}/${path}/remote.php/dav/files/admin/${fileName}`,
+        'Authorization': 'Basic ' + encoding.b64encode('admin:admin'),
+    };
+
+    const url = `${host}/${path}/remote.php/dav/trash-bin/admin/${fileId}/`;
+
+    const response = http.request('MOVE', url, undefined, { headers: headers });
+    check(response, {
+        'status is 201': (r) => r.status === 201,
+    });
+    if (response.status === 201) {
+    } else {
+        console.log(response.status);
+        console.log(response.body);
+    }
+};
+
+export default function(fileIdArrays) {
+    // Since all the 10 VU cannot restore the same file(blocking), fileIds array is divided into 10 chunks
+    // and each VU will restore file from their respecive chunk
+    switch (__VU) {
+        case 1:
+            restoreFile(fileIdArrays[0][__ITER]);
+            break;
+        case 2:
+            restoreFile(fileIdArrays[1][__ITER]);
+            break;
+        case 3:
+            restoreFile(fileIdArrays[2][__ITER]);
+            break;
+        case 4:
+            restoreFile(fileIdArrays[3][__ITER]);
+            break;
+        case 5:
+            restoreFile(fileIdArrays[4][__ITER]);
+            break;
+        case 6:
+            restoreFile(fileIdArrays[5][__ITER]);
+            break;
+        case 7:
+            restoreFile(fileIdArrays[6][__ITER]);
+            break;
+        case 8:
+            restoreFile(fileIdArrays[7][__ITER]);
+            break;
+        case 9:
+            restoreFile(fileIdArrays[8][__ITER]);
+            break;
+        case 10:
+            restoreFile(fileIdArrays[9][__ITER]);
+    }
+    sleep(0.5);
+}


### PR DESCRIPTION
### Description
This PR is to demonstrate bug specified in issue https://github.com/owncloud/core/issues/38265 using k6 benchmark test.

### Steps to reproduce

k6 must be installed on your machine   https://k6.io/docs/getting-started/installation/
1. To reproduce the issue locally first we need to create and delete 200000 files. To achieve this run `create-delete-files.js` using command:

```
k6 run create-delete-files.js
```

2. After step 1, we need to restore those deleted files. For this run

```
k6 run restore-files.js --console-output=./log.txt
```

Here, the o/p of fails is logged in `log.txt`. Most of the fails are due to `files/4d1f8bdc6d1525444a0085af56d60acb" is locked` error,  but the file is restored while some fails are due to `The destination node already exists, and the overwrite header is set to false` error, which this PR is intended to demonstrate.

