### PR TITLE
Add trash features (trash and restore) with minor linting fix

### DIFF
--- a/src/k6/src/lib/api/dav.ts
+++ b/src/k6/src/lib/api/dav.ts
@@ -93,11 +93,11 @@ export class Create {
 
 export class Propfind {
     public static exec({
-                           credential,
-                           userName,
-                           path = '',
-                           tags,
-                       }: {
+        credential,
+        userName,
+        path = '',
+        tags,
+    }: {
         credential: types.Credential;
         userName: string;
         path?: string;
@@ -114,12 +114,12 @@ export class Propfind {
 
 export class Move {
     public static exec({
-                           credential,
-                           userName,
-                           path,
-                           destination,
-                           tags,
-                       }: {
+        credential,
+        userName,
+        path,
+        destination,
+        tags,
+    }: {
         credential: types.Credential;
         userName: string;
         path: string;
@@ -133,7 +133,54 @@ export class Move {
             params: { tags },
             headers: {
                 destination: `/remote.php/dav/files/${userName}/${destination}`,
-            }
+            },
+        });
+    }
+}
+export class Trash {
+    public static exec({
+        credential,
+        userName,
+        fileid = '',
+        tags,
+    }: {
+        credential: types.Credential;
+        userName: string;
+        fileid?: string;
+        tags?: types.Tags;
+    }): RefinedResponse<ResponseType> {
+        return api.request({
+            method: 'DELETE',
+            credential,
+            path: `/remote.php/dav/trash-bin/${userName}/${fileid}`,
+            params: { tags },
+        });
+    }
+}
+
+export class Restore {
+    public static exec({
+        credential,
+        userName,
+        fileid = '',
+        path = '',
+        tags,
+    }: {
+        credential: types.Credential;
+        userName: string;
+        fileid?: string;
+        path?: string;
+        tags?: types.Tags;
+    }): RefinedResponse<ResponseType> {
+        return api.request({
+            method: 'MOVE',
+            credential,
+            path: `/remote.php/dav/trash-bin/${userName}/${fileid}`,
+            params: { tags },
+            headers: {
+                destination: `/remote.php/dav/files/${userName}/${path}`,
+                overwrite: 'F',
+            },
         });
     }
 }

--- a/src/k6/src/lib/playbook/dav.ts
+++ b/src/k6/src/lib/playbook/dav.ts
@@ -149,11 +149,11 @@ export class Propfind extends Play {
     }
 
     public exec({
-                    credential,
-                    userName,
-                    path,
-                    tags,
-                }: {
+        credential,
+        userName,
+        path,
+        tags,
+    }: {
         credential: types.Credential;
         path?: string;
         userName: string;
@@ -177,19 +177,18 @@ export class Propfind extends Play {
     }
 }
 
-
 export class Move extends Play {
     constructor({ name, metricID = 'default' }: { name?: string; metricID?: string } = {}) {
         super({ name: name || `cloud_${metricID}_play_dav_move` });
     }
 
     public exec({
-                    credential,
-                    userName,
-                    path,
-                    destination,
-                    tags,
-                }: {
+        credential,
+        userName,
+        path,
+        destination,
+        tags,
+    }: {
         credential: types.Credential;
         path: string;
         destination: string;
@@ -204,6 +203,75 @@ export class Move extends Play {
             response,
             {
                 'dav move status is 201': () => response.status === 201,
+            },
+            tags,
+        ) || this.metricErrorRate.add(1, tags);
+
+        this.metricTrend.add(response.timings.duration, tags);
+
+        return { response, tags };
+    }
+}
+
+export class Trash extends Play {
+    constructor({ name, metricID = 'default' }: { name?: string; metricID?: string } = {}) {
+        super({ name: name || `cloud_${metricID}_play_dav_trash_delete` });
+    }
+
+    public exec({
+        credential,
+        userName,
+        fileid,
+        tags,
+    }: {
+        credential: types.Credential;
+        fileid?: string;
+        userName: string;
+        tags?: types.Tags;
+    }): { response: RefinedResponse<ResponseType>; tags: types.Tags } {
+        tags = { ...this.tags, ...tags };
+
+        const response = api.dav.Trash.exec({ credential: credential, userName, tags, fileid });
+
+        check(
+            response,
+            {
+                'dav trash delete status is 204': () => response.status === 204,
+            },
+            tags,
+        ) || this.metricErrorRate.add(1, tags);
+
+        this.metricTrend.add(response.timings.duration, tags);
+
+        return { response, tags };
+    }
+}
+
+export class Restore extends Play {
+    constructor({ name, metricID = 'default' }: { name?: string; metricID?: string } = {}) {
+        super({ name: name || `cloud_${metricID}_play_dav_trash_restore` });
+    }
+
+    public exec({
+        credential,
+        userName,
+        fileid,
+        path,
+        tags,
+    }: {
+        credential: types.Credential;
+        fileid?: string;
+        path?: string;
+        userName: string;
+        tags?: types.Tags;
+    }): { response: RefinedResponse<ResponseType>; tags: types.Tags } {
+        tags = { ...this.tags, ...tags };
+
+        const response = api.dav.Restore.exec({ credential: credential, userName, tags, fileid, path });
+        check(
+            response,
+            {
+                'dav trash restore status is 201': () => response.status === 201,
             },
             tags,
         ) || this.metricErrorRate.add(1, tags);


### PR DESCRIPTION
I found there was a feature **Trash.Restore** on a branch in this repo (see https://github.com/owncloud/cdperf/blob/load-test-scenario/src/k6/src/lib/api/dav/trashBin.ts) which appeared to be broken, but would be useful to include in many load test scenarios.

I have fixed the issue (it was attempting to use the file path, rather than the metadata **fileid** for the DELETE command.
Likewise I have added a restore command (which requires some custom headers) so you can test the full lifecycle of creating, deleting then restoring (or erasing from trash) a given file in the system.

I have tested both of these locally with example scripts and they work perfectly.  I can raise PRs for these test cases if you would like to see them added (separately).

I did notice, if you specify **overwrite: T** in the headers for the trash restore command, it will return a 204 rather than a 201 but I have not implemented this conditional validation, as it does not seem like a good idea for load testing.