### PR TITLE
set ocis insecure flag

### DIFF
--- a/scripts/cdperf
+++ b/scripts/cdperf
@@ -234,6 +234,7 @@ then
   [[ ! $cloud_docker_image ]] && cloud_docker_image="owncloud/ocis"
   [[ ! $cloud_docker_publish ]] && cloud_docker_publish="9200:9200"
   [[ $cloud_oidc != true ]] && cloud_docker_env+=("PROXY_ENABLE_BASIC_AUTH=true")
+  cloud_docker_env+=("OCIS_INSECURE=true")
 elif [[ $cloud_vendor == "oc10" ]]
 then
   [[ ! $cloud_docker_image ]] && cloud_docker_image="owncloud/server"


### PR DESCRIPTION
set `cloud_docker_env+=("OCIS_INSECURE=true")`

the insecure option was introduced in [#2745](https://github.com/owncloud/ocis/pull/2745)
it needs to be added here because its `false` by default and by that would not accept self-signed certificates