### PR TITLE
support for influxDB v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ $
 $ # test with docker ocis and local k6
 $ ./scripts/cdperf --cloud-vendor=ocis --k6-test-host=https://localhost:9200 --k6-docker=false
 $
-$ # export test results to influxdb
+$ # export test results to influxdb v1
 $ ./scripts/cdperf --cloud-vendor=ocis --k6-test-host=https://host.docker.internal:9200 --k6-out=influxdb=http://admin:admin@host.docker.internal:8086/k6
+$
+$ # export test results to influxdb v2
+$ ./scripts/cdperf --cloud-vendor=ocis --k6-test-host=https://host.docker.internal:9200 --k6-out=xk6-influxdb=http://host.docker.internal:8086 --k6-influxdb-token="superlongadmintoken"
 $
 $ # with cloud on remote docker host
 $ ./scripts/cdperf --cloud-docker-host=ssh://user@your-host --cloud-vendor=ocis --k6-test-host=https://your-host:9200

--- a/scripts/cdperf
+++ b/scripts/cdperf
@@ -31,6 +31,9 @@ k6_quiet=${CDPERF_K6_QUIET:-}
 k6_cloud_id=${CDPERF_K6_CLOUD_ID:-}
 k6_cloud_login=${CDPERF_K6_CLOUD_LOGIN:-"admin"}
 k6_cloud_password=${CDPERF_K6_CLOUD_PASSWORD:-"admin"}
+k6_influxdb_organization=${CDPERF_K6_INFLUXDB_ORGANIZATION:-"k6-benchmark"}
+k6_influxdb_bucket=${CDPERF_K6_INFLUXDB_BUCKET:-"k6-benchmark"}
+k6_influxdb_token=${CDPERF_K6_INFLUXDB_TOKEN:-""}
 
 usage(){
   echo "cdPerf: ownCloud cloud performance test"
@@ -117,6 +120,18 @@ usage(){
   echo "                                Default: admin"
   echo "                                ENV: CDPERF_K6_CLOUD_PASSWORD"
   echo "                                --"
+  echo " --k6-influxdb-organization     Name of organization when using with InfluxDB v2"
+  echo "                                Default: k6-benchmark"
+  echo "                                ENV: CDPERF_K6_INFLUXDB_ORGANIZATION"
+  echo "                                --"
+  echo " --k6-influxdb-bucket           Name of bucket when using with InfluxDB v2"
+  echo "                                Default: k6-benchmark"
+  echo "                                ENV: CDPERF_K6_INFLUXDB_BUCKET"
+  echo "                                --"
+  echo " --k6-influxdb-token            Token when using with InfluxDB v2"
+  echo "                                Default: "
+  echo "                                ENV: CDPERF_K6_INFLUXDB_TOKEN"
+  echo "                                --"
   echo " --k6-csv                       Output results file to CSV"
   echo "                                ENV: CDPERF_K6_CSV"
   echo "                                --"
@@ -202,6 +217,18 @@ while test $# -gt 0; do
             ;;
         --k6-cloud-password=*)
             k6_cloud_password="${1#*=}"
+            shift
+            ;;
+        --k6-influxdb-organization=*)
+            k6_influxdb_organization="${1#*=}"
+            shift
+            ;;
+        --k6-influxdb-bucket=*)
+            k6_influxdb_bucket="${1#*=}"
+            shift
+            ;;
+        --k6-influxdb-token=*)
+            k6_influxdb_token="${1#*=}"
             shift
             ;;
         --k6-csv=*)
@@ -303,6 +330,9 @@ function k6_run(){
   [[ $cloud_oidc == true ]] && k6_env+=("CLOUD_OIDC_ENABLED=$cloud_oidc")
   [[ $cloud_vendor ]] && k6_env+=("CLOUD_VENDOR=$cloud_vendor")
   [[ $cloud_oidc_issuer ]] && k6_env+=("CLOUD_OIDC_ISSUER=$cloud_oidc_issuer")
+  [[ $k6_influxdb_organization ]] && k6_env+=("K6_INFLUXDB_ORGANIZATION=$k6_influxdb_organization")
+  [[ $k6_influxdb_bucket ]] && k6_env+=("K6_INFLUXDB_BUCKET=$k6_influxdb_bucket")
+  [[ $k6_influxdb_token ]] && k6_env+=("K6_INFLUXDB_TOKEN=$k6_influxdb_token")
 
   for i in "${!k6_env[@]}"
   do

--- a/src/k6/Dockerfile
+++ b/src/k6/Dockerfile
@@ -1,4 +1,9 @@
-FROM loadimpact/k6 as k6
+FROM golang as k6
+
+RUN go install go.k6.io/xk6/cmd/xk6@latest && \
+    xk6 build --with github.com/grafana/xk6-output-influxdb
+
+
 FROM node:15-alpine as node
 
 WORKDIR /k6
@@ -12,7 +17,7 @@ RUN yarn build
 FROM alpine:3
 
 COPY --from=node /k6/dist /scripts
-COPY --from=k6 /usr/bin/k6 /usr/bin/k6
+COPY --from=k6 /go/k6 /usr/bin/k6
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.label-schema.name="ownCloud measure" \


### PR DESCRIPTION
to run K6 with InfluxDB v2 it has to be compiled with an extension https://github.com/grafana/xk6-output-influxdb

ToDo:
- [x] test with influxDB v1 (tested with influxdb:1.8.5)
