### PR TITLE
Enable local builds (much faster than using docker for development)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.ONESHELL:
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: build
@@ -5,6 +6,12 @@ build:
 	docker build --tag owncloud/cdperf-k6 src/k6
 	docker run --rm --volume $(ROOT_DIR)/tests/k6:/cp owncloud/cdperf-k6 cp -r . /cp
 	chmod +x ./scripts/cdperf
+
+.PHONY: local
+local: clean
+	cd src/k6 && yarn && yarn build
+	mkdir -p tests/k6
+	cp -R src/k6/dist/. tests/k6/
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Supported clouds are:
 To see available options run ./scripts/cdperf --help
 
 ```shell
+$ # build via docker
 $ make clean build
+$
+$ # alternatively, build locally (requires node + yarn installed)
+$ make local
 $
 $ # all available options
 $ ./scripts/cdperf --help


### PR DESCRIPTION
Updated the docs, happy to amend if there are any suggestions, this shouldn't differ the final output from the `make build` command but it is much faster for local development of tests.

Also solves the annoying issue of the `tests/k6` folder being owned by root when using `make build` (via docker).