### PR TITLE
Add trash and restore tests

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -57,6 +57,46 @@ The files are uploaded, downloaded and deleted.
 
 This measures the up- and download speed of smaller files.
 
+### Upload, Delete and Trash Big Files
+
+Script: `/root/cdperf/tests/k6/test-issue-github-ocis-1018-upload-delete-trash-many-large.js`
+
+In total this test creates 5 GB of files which are distributed from 5 MB up to 1 GB per file.
+
+The files are uploaded, deleted and removed from trash afterwards.
+
+This gives an indication about the transmission speed of big files and tests the performance of trashing those files.
+
+### Upload, Delete and Trash Small Files
+
+Script: `/root/cdperf/tests/k6/test-issue-github-ocis-1018-upload-delete-trash-many-small.js`
+
+This test creates files between 500 kB and 25 MB, with a total size of 1.7 GB.
+
+The files are uploaded, deleted and removed from trash afterwards.
+
+This gives an indication about the transmission speed of smaller files and tests the performance of trashing those files.
+
+### Upload, Delete and Restore Big Files
+
+Script: `/root/cdperf/tests/k6/test-issue-github-ocis-1018-upload-delete-restore-many-large.js`
+
+In total this test creates 5 GB of files which are distributed from 5 MB up to 1 GB per file.
+
+The files are uploaded, deleted and restored from trash afterwards.
+
+This gives an indication about the transmission speed of big files and tests the performance of restoring those files from trash.
+
+### Upload, Delete and Restore Small Files
+
+Script: `/root/cdperf/tests/k6/test-issue-github-ocis-1018-upload-delete-restore-many-small.js`
+
+This test creates files between 500 kB and 25 MB, with a total size of 1.7 GB.
+
+The files are uploaded, deleted and restored from trash afterwards.
+
+This gives an indication about the transmission speed of smaller files and tests the performance of restoring those files from trash.
+
 ### Up- and Download with New User
 
 Script: `/root/cdperf/tests/k6/test-issue-github-ocis-1018-upload-download-delete-with-new-user.js`

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -95,9 +95,9 @@ This test creates files between 500 kB and 25 MB, with a total size of 1.7 GB.
 
 The files are uploaded, deleted and restored from trash afterwards.
 
-This gives an indication about the transmission speed of smaller files and tests the performance of restoring those files from trash.
+This gives an indication about the transmission speed of smallert files and tests the performance of restoring those files from trash.
 
-### Up- and Download with New User
+### Upload and Download with New User
 
 Script: `/root/cdperf/tests/k6/test-issue-github-ocis-1018-upload-download-delete-with-new-user.js`
 

--- a/src/k6/package.json
+++ b/src/k6/package.json
@@ -34,7 +34,7 @@
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/pluginutils": "^4.1.0",
-    "@types/k6": "^0.28.2",
+    "@types/k6": "^0.35.2",
     "@types/lodash": "^4.14.165",
     "@types/xmldom": "^0.1.30",
     "@typescript-eslint/eslint-plugin": "^4.9.0",

--- a/src/k6/src/lib/api/dav.ts
+++ b/src/k6/src/lib/api/dav.ts
@@ -97,17 +97,20 @@ export class Propfind {
         userName,
         path = '',
         tags,
+        body = '',
     }: {
         credential: types.Credential;
         userName: string;
         path?: string;
         tags?: types.Tags;
+        body?: string;
     }): RefinedResponse<ResponseType> {
         return api.request({
             method: 'PROPFIND',
             credential,
             path: `/remote.php/dav/files/${userName}/${path}`,
             params: { tags },
+            body,
         });
     }
 }

--- a/src/k6/src/lib/playbook/dav.ts
+++ b/src/k6/src/lib/playbook/dav.ts
@@ -153,15 +153,17 @@ export class Propfind extends Play {
         userName,
         path,
         tags,
+        body,
     }: {
         credential: types.Credential;
         path?: string;
         userName: string;
         tags?: types.Tags;
+        body?: string;
     }): { response: RefinedResponse<ResponseType>; tags: types.Tags } {
         tags = { ...this.tags, ...tags };
 
-        const response = api.dav.Propfind.exec({ credential: credential, userName, tags, path });
+        const response = api.dav.Propfind.exec({ credential: credential, userName, tags, path, body });
 
         check(
             response,

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_large.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_large.ts
@@ -24,7 +24,7 @@ const plays = {
 
 export const options: Options = k6.options({
     tags: {
-        test_id: 'upload-download-restore-many-large',
+        test_id: 'upload-delete-restore-many-large',
         issue_url: 'github.com/owncloud/ocis/issues/1018',
     },
     ...uploadDeleteTrashRestoreOptions({ plays, files }),

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_large.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_large.ts
@@ -18,6 +18,7 @@ const files: {
 const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
 const plays = {
     davUpload: new playbook.dav.Upload(),
+    davPropfind: new playbook.dav.Propfind(),
     davDelete: new playbook.dav.Delete(),
     davRestore: new playbook.dav.Restore(),
 };

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_large.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_large.ts
@@ -1,0 +1,34 @@
+import { Options } from 'k6/options';
+
+import { auth, defaults, k6, playbook, types, utils } from '../../../../../../lib';
+import { default as uploadDeleteTrashRestore, options as uploadDeleteTrashRestoreOptions } from './shared.lib';
+
+// upload, delete and restore of many files with several sizes and summary size of 500 MB in one directory
+const files: {
+    size: number;
+    unit: types.AssetUnit;
+}[] = [
+    { size: 50, unit: 'KB' },
+    { size: 500, unit: 'KB' },
+    { size: 5, unit: 'MB' },
+    { size: 50, unit: 'MB' },
+    { size: 500, unit: 'MB' },
+    { size: 1, unit: 'GB' },
+];
+const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
+const plays = {
+    davUpload: new playbook.dav.Upload(),
+    davDelete: new playbook.dav.Delete(),
+    davRestore: new playbook.dav.Restore(),
+};
+
+export const options: Options = k6.options({
+    tags: {
+        test_id: 'upload-download-restore-many-large',
+        issue_url: 'github.com/owncloud/ocis/issues/1018',
+    },
+    ...uploadDeleteTrashRestoreOptions({ plays, files }),
+});
+
+export default (): void =>
+    uploadDeleteTrashRestore({ files, plays, credential: authFactory.credential, account: authFactory.account });

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_small.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_small.ts
@@ -1,0 +1,32 @@
+import { Options } from 'k6/options';
+import { times } from 'lodash';
+
+import { auth, defaults, k6, playbook, types, utils } from '../../../../../../lib';
+import { default as uploadDeleteTrashRestore, options as uploadDeleteTrashRestoreOptions } from './shared.lib';
+
+// upload, delete and restore of many files with several sizes and summary size of 500 MB in one directory
+const files: {
+    size: number;
+    unit: types.AssetUnit;
+}[] = [
+    ...times(1, () => ({ size: 500, unit: 'KB' as types.AssetUnit })),
+    ...times(50, () => ({ size: 5, unit: 'MB' as types.AssetUnit })),
+    ...times(10, () => ({ size: 25, unit: 'MB' as types.AssetUnit })),
+];
+const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
+const plays = {
+    davUpload: new playbook.dav.Upload(),
+    davDelete: new playbook.dav.Delete(),
+    davRestore: new playbook.dav.Restore(),
+};
+
+export const options: Options = k6.options({
+    tags: {
+        test_id: 'upload-delete-restore-many-small',
+        issue_url: 'github.com/owncloud/ocis/issues/1018',
+    },
+    ...uploadDeleteTrashRestoreOptions({ plays, files }),
+});
+
+export default (): void =>
+    uploadDeleteTrashRestore({ files, plays, credential: authFactory.credential, account: authFactory.account });

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_small.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/many_small.ts
@@ -16,6 +16,7 @@ const files: {
 const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
 const plays = {
     davUpload: new playbook.dav.Upload(),
+    davPropfind: new playbook.dav.Propfind(),
     davDelete: new playbook.dav.Delete(),
     davRestore: new playbook.dav.Restore(),
 };

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/shared.lib.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_restore/shared.lib.ts
@@ -1,0 +1,81 @@
+import { b64decode } from 'k6/encoding';
+import { Options, Threshold } from 'k6/options';
+
+import { playbook, types, utils } from '../../../../../../lib';
+
+interface File {
+    size: number;
+    unit: types.AssetUnit;
+}
+
+interface Plays {
+    davUpload: playbook.dav.Upload;
+    davDelete: playbook.dav.Delete;
+    davRestore: playbook.dav.Restore;
+}
+
+export const options = ({ files, plays }: { files: File[]; plays: Plays }): Options => {
+    return {
+        thresholds: files.reduce((acc: { [name: string]: Threshold[] }, c) => {
+            acc[`${plays.davUpload.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            acc[`${plays.davDelete.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            acc[`${plays.davRestore.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            return acc;
+        }, {}),
+    };
+};
+
+export default ({
+    files,
+    account,
+    credential,
+    plays,
+}: {
+    plays: Plays;
+    files: File[];
+    account: types.Account;
+    credential: types.Credential;
+}): void => {
+    const filesUploaded: { id: string; name: string; fileid: string }[] = [];
+
+    files.forEach((f) => {
+        const id = f.unit + f.size.toString();
+
+        const asset = utils.buildAsset({
+            name: `${account.login}-dummy.zip`,
+            unit: f.unit,
+            size: f.size,
+        });
+
+        const output = plays.davUpload.exec({
+            credential,
+            asset,
+            userName: account.login,
+            tags: { asset: id },
+        });
+
+        const base64Fileid = output.response.headers['Oc-Fileid'];
+        const fileid = b64decode(base64Fileid, 'std', 's').split(':')[1];
+
+        filesUploaded.push({ id, name: asset.name, fileid: fileid });
+    });
+
+    filesUploaded.forEach((f) => {
+        plays.davDelete.exec({
+            credential,
+            userName: account.login,
+            path: f.name,
+            tags: { asset: f.id },
+        });
+    });
+
+    filesUploaded.forEach((f) => {
+        plays.davRestore.exec({
+            credential,
+            userName: account.login,
+            fileid: f.fileid,
+            path: f.name,
+            tags: { asset: f.id },
+        });
+    });
+};

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_large.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_large.ts
@@ -1,0 +1,34 @@
+import { Options } from 'k6/options';
+
+import { auth, defaults, k6, playbook, types, utils } from '../../../../../../lib';
+import { default as uploadDeleteTrashRestore, options as uploadDeleteTrashRestoreOptions } from './shared.lib';
+
+// upload, delete and trash of many files with several sizes and summary size of 500 MB in one directory
+const files: {
+    size: number;
+    unit: types.AssetUnit;
+}[] = [
+    { size: 50, unit: 'KB' },
+    { size: 500, unit: 'KB' },
+    { size: 5, unit: 'MB' },
+    { size: 50, unit: 'MB' },
+    { size: 500, unit: 'MB' },
+    { size: 1, unit: 'GB' },
+];
+const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
+const plays = {
+    davUpload: new playbook.dav.Upload(),
+    davDelete: new playbook.dav.Delete(),
+    davTrash: new playbook.dav.Trash(),
+};
+
+export const options: Options = k6.options({
+    tags: {
+        test_id: 'upload-download-delete-many-large',
+        issue_url: 'github.com/owncloud/ocis/issues/1018',
+    },
+    ...uploadDeleteTrashRestoreOptions({ plays, files }),
+});
+
+export default (): void =>
+    uploadDeleteTrashRestore({ files, plays, credential: authFactory.credential, account: authFactory.account });

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_large.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_large.ts
@@ -18,6 +18,7 @@ const files: {
 const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
 const plays = {
     davUpload: new playbook.dav.Upload(),
+    davPropfind: new playbook.dav.Propfind(),
     davDelete: new playbook.dav.Delete(),
     davTrash: new playbook.dav.Trash(),
 };

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_large.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_large.ts
@@ -24,7 +24,7 @@ const plays = {
 
 export const options: Options = k6.options({
     tags: {
-        test_id: 'upload-download-delete-many-large',
+        test_id: 'upload-delete-trash-many-large',
         issue_url: 'github.com/owncloud/ocis/issues/1018',
     },
     ...uploadDeleteTrashRestoreOptions({ plays, files }),

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_small.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_small.ts
@@ -16,6 +16,7 @@ const files: {
 const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
 const plays = {
     davUpload: new playbook.dav.Upload(),
+    davPropfind: new playbook.dav.Propfind(),
     davDelete: new playbook.dav.Delete(),
     davTrash: new playbook.dav.Trash(),
 };

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_small.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/many_small.ts
@@ -1,0 +1,32 @@
+import { Options } from 'k6/options';
+import { times } from 'lodash';
+
+import { auth, defaults, k6, playbook, types, utils } from '../../../../../../lib';
+import { default as uploadDeleteTrashRestore, options as uploadDeleteTrashRestoreOptions } from './shared.lib';
+
+// upload, delete and trash of many files with several sizes and summary size of 500 MB in one directory
+const files: {
+    size: number;
+    unit: types.AssetUnit;
+}[] = [
+    ...times(1, () => ({ size: 500, unit: 'KB' as types.AssetUnit })),
+    ...times(50, () => ({ size: 5, unit: 'MB' as types.AssetUnit })),
+    ...times(10, () => ({ size: 25, unit: 'MB' as types.AssetUnit })),
+];
+const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
+const plays = {
+    davUpload: new playbook.dav.Upload(),
+    davDelete: new playbook.dav.Delete(),
+    davTrash: new playbook.dav.Trash(),
+};
+
+export const options: Options = k6.options({
+    tags: {
+        test_id: 'upload-delete-trash-many-small',
+        issue_url: 'github.com/owncloud/ocis/issues/1018',
+    },
+    ...uploadDeleteTrashRestoreOptions({ plays, files }),
+});
+
+export default (): void =>
+    uploadDeleteTrashRestore({ files, plays, credential: authFactory.credential, account: authFactory.account });

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/shared.lib.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/shared.lib.ts
@@ -1,0 +1,80 @@
+import { b64decode } from 'k6/encoding';
+import { Options, Threshold } from 'k6/options';
+
+import { playbook, types, utils } from '../../../../../../lib';
+
+interface File {
+    size: number;
+    unit: types.AssetUnit;
+}
+
+interface Plays {
+    davUpload: playbook.dav.Upload;
+    davDelete: playbook.dav.Delete;
+    davTrash: playbook.dav.Trash;
+}
+
+export const options = ({ files, plays }: { files: File[]; plays: Plays }): Options => {
+    return {
+        thresholds: files.reduce((acc: { [name: string]: Threshold[] }, c) => {
+            acc[`${plays.davUpload.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            acc[`${plays.davDelete.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            acc[`${plays.davTrash.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            return acc;
+        }, {}),
+    };
+};
+
+export default ({
+    files,
+    account,
+    credential,
+    plays,
+}: {
+    plays: Plays;
+    files: File[];
+    account: types.Account;
+    credential: types.Credential;
+}): void => {
+    const filesUploaded: { id: string; name: string; fileid: string }[] = [];
+
+    files.forEach((f) => {
+        const id = f.unit + f.size.toString();
+
+        const asset = utils.buildAsset({
+            name: `${account.login}-dummy.zip`,
+            unit: f.unit,
+            size: f.size,
+        });
+
+        const output = plays.davUpload.exec({
+            credential,
+            asset,
+            userName: account.login,
+            tags: { asset: id },
+        });
+
+        const base64Fileid = output.response.headers['Oc-Fileid'];
+        const fileid = b64decode(base64Fileid, 'std', 's').split(':')[1];
+
+        filesUploaded.push({ id, name: asset.name, fileid: fileid });
+    });
+
+    filesUploaded.forEach((f) => {
+        plays.davDelete.exec({
+            credential,
+            userName: account.login,
+            path: f.name,
+            tags: { asset: f.id },
+        });
+    });
+
+    filesUploaded.forEach((f) => {
+        plays.davTrash.exec({
+            credential,
+            userName: account.login,
+            fileid: f.fileid,
+            tags: { asset: f.id },
+        });
+    });
+};

--- a/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/shared.lib.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/upload_delete_trash/shared.lib.ts
@@ -1,4 +1,3 @@
-import { b64decode } from 'k6/encoding';
 import { Options, Threshold } from 'k6/options';
 
 import { playbook, types, utils } from '../../../../../../lib';
@@ -10,6 +9,7 @@ interface File {
 
 interface Plays {
     davUpload: playbook.dav.Upload;
+    davPropfind: playbook.dav.Propfind;
     davDelete: playbook.dav.Delete;
     davTrash: playbook.dav.Trash;
 }
@@ -18,6 +18,7 @@ export const options = ({ files, plays }: { files: File[]; plays: Plays }): Opti
     return {
         thresholds: files.reduce((acc: { [name: string]: Threshold[] }, c) => {
             acc[`${plays.davUpload.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
+            acc[`${plays.davPropfind.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
             acc[`${plays.davDelete.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
             acc[`${plays.davTrash.metricTrendName}{asset:${c.unit + c.size.toString()}}`] = [];
             return acc;
@@ -47,16 +48,24 @@ export default ({
             size: f.size,
         });
 
-        const output = plays.davUpload.exec({
+        plays.davUpload.exec({
             credential,
             asset,
             userName: account.login,
             tags: { asset: id },
         });
 
-        const base64Fileid = output.response.headers['Oc-Fileid'];
-        const fileid = b64decode(base64Fileid, 'std', 's').split(':')[1];
+        const propfindOutput = plays.davPropfind.exec({
+            credential,
+            userName: account.login,
+            tags: { asset: id },
+            path: asset.name,
+            body:
+                '<?xml version="1.0"?><d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns"><d:prop><oc:fileid /></d:prop></d:propfind>',
+        });
 
+        const fileid = utils.parseXML(propfindOutput.response.body).getElementsByTagName('oc:fileid')[0].childNodes[0]
+            .textContent as string;
         filesUploaded.push({ id, name: asset.name, fileid: fileid });
     });
 

--- a/src/k6/yarn.lock
+++ b/src/k6/yarn.lock
@@ -949,10 +949,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/k6@^0.28.2":
-  version "0.28.3"
-  resolved "https://registry.yarnpkg.com/@types/k6/-/k6-0.28.3.tgz#69ab758f450e558722dff553ab3eb5542892a440"
-  integrity sha512-qUOneA7Zn8erpBxhFkkshr6lRNKYIBGo0MjNQWaepGcbegfQaQy0fVIlHYjTJhlqxnmwDZPNkKbIrTpL0VHb6A==
+"@types/k6@^0.35.2":
+  version "0.35.2"
+  resolved "https://registry.yarnpkg.com/@types/k6/-/k6-0.35.2.tgz#e544be35e65c9225cec47d5f96f2de0e2bcbd549"
+  integrity sha512-5R8PRMHszrPJBvLSX4CJoxu3aUzzRKg0wFwTapiNj3hQ1cr/DPgayl6fmR4MXegI/G/zer4QalppMoSxIvrUVg==
 
 "@types/lodash@^4.14.165":
   version "4.14.168"


### PR DESCRIPTION
Following the merge of https://github.com/owncloud/cdperf/pull/16 here are some tests that leverage the `Trash` and `Restore` functions in K6 load tests.