### PR TITLE
use auth when waiting for ocis to come online

### DIFF
--- a/scripts/cdperf
+++ b/scripts/cdperf
@@ -384,7 +384,7 @@ function start(){
 
 # wait for cloud container to be ready
 wait_host="${k6_test_host/host.docker.internal/localhost}"
-until curl --output /dev/null --head --fail --silent --insecure "$wait_host"; do
+until curl --output /dev/null --head --fail --silent --insecure "$wait_host" -uadmin:admin; do
   echo "waiting for '$cloud_vendor' on '$wait_host'"
   sleep 1
 done


### PR DESCRIPTION
who can solve this riddle? After a lot of trying around I found out that the tests break when sending this "waiting" request without username & password, but just adding that makes them pass again.
I could not reproduce the problem when just running a compiled version of ocis, only when running it from docker, but that might be a timing issue.

Maybe related to https://github.com/owncloud/ocis/issues/2964