### PR TITLE
distinguish propfind-deep tests

### DIFF
--- a/src/k6/src/test/issue/github/ocis/1018/propfind/deep_100_files_45_nested_folders.ts
+++ b/src/k6/src/test/issue/github/ocis/1018/propfind/deep_100_files_45_nested_folders.ts
@@ -12,7 +12,7 @@ const files: {
 const authFactory = new auth(utils.buildAccount({ login: defaults.ACCOUNTS.EINSTEIN }));
 export const options: Options = k6.options({
     tags: {
-        test_id: 'propfind-deep',
+        test_id: 'propfind-deep-45',
         issue_url: 'github.com/owncloud/ocis/issues/1018',
     },
     ...propfindOptions({ files }),


### PR DESCRIPTION
we have two tests with the tag `propfind-deep`. they are therefore not distinguishable in the grafana charts and create an ugly zigzag graph (https://grafana.k6.infra.owncloud.works/d/8IV_hHt7k/test-durations?orgId=1&from=now-7d&to=now)

![image](https://user-images.githubusercontent.com/34452982/159643622-0d31caae-33ca-4bb1-a0e5-19239d1b0828.png)
