### PR TITLE
Add interactive docker terminal to get a proper k6 output

### DIFF
--- a/scripts/cdperf
+++ b/scripts/cdperf
@@ -18,6 +18,7 @@ cloud_oidc_issuer=${CDPERF_CLOUD_OIDC_ISSUER:-}
 cloud_vendor=${CDPERF_CLOUD_VENDOR:-"ocis"}
 
 k6_docker=${CDPERF_K6_DOCKER:-"true"}
+k6_docker_interactive=${CDPERF_K6_DOCKER_INTERACTIVE:-"false"}
 k6_vus=${CDPERF_K6_VUS:-"3"}
 k6_iterations=${CDPERF_K6_ITERATIONS:-"3"}
 k6_duration=${CDPERF_K6_DURATION:-"1h0m0s"}
@@ -80,6 +81,11 @@ usage(){
   echo "                                  Supported values: ( true | false )"
   echo "                                  Default: true"
   echo "                                  ENV: CDPERF_K6_DOCKER"
+  echo "                                  --"
+  echo " --k6-docker-interactive          Use docker interactive mode to run k6"
+  echo "                                  Supported values: ( true | false )"
+  echo "                                  Default: false"
+  echo "                                  ENV: CDPERF_K6_DOCKER_INTERACTIVE"
   echo "                                  --"
   echo " --k6-vus                         K6 number of virtual users"
   echo "                                  Default: 3"
@@ -187,6 +193,10 @@ while test $# -gt 0; do
             ;;
         --k6-docker=*)
             k6_docker="${1#*=}"
+            shift
+            ;;
+        --k6-docker-interactive=*)
+            k6_docker_interactive="${1#*=}"
             shift
             ;;
         --k6-vus=*)
@@ -368,7 +378,12 @@ function k6_run(){
       if [[ $k6_docker == true ]]
       then
         # shellcheck disable=SC2068
-        docker run -it ${k6_env[@]} --add-host=host.docker.internal:host-gateway --rm "owncloud/cdperf-k6" k6 run "${k6_params[@]}" "$(basename "$t")"
+        if [[ $k6_docker_interactive == false ]]
+        then
+          docker run ${k6_env[@]} --add-host=host.docker.internal:host-gateway --rm "owncloud/cdperf-k6" k6 run "${k6_params[@]}" "$(basename "$t")"
+        else
+          docker run -it ${k6_env[@]} --add-host=host.docker.internal:host-gateway --rm "owncloud/cdperf-k6" k6 run "${k6_params[@]}" "$(basename "$t")"
+        fi
       else
         # shellcheck disable=SC2068
         k6 run ${k6_params[@]} "$t"

--- a/scripts/cdperf
+++ b/scripts/cdperf
@@ -368,7 +368,7 @@ function k6_run(){
       if [[ $k6_docker == true ]]
       then
         # shellcheck disable=SC2068
-        docker run ${k6_env[@]} --add-host=host.docker.internal:host-gateway --rm "owncloud/cdperf-k6" k6 run "${k6_params[@]}" "$(basename "$t")"
+        docker run -it ${k6_env[@]} --add-host=host.docker.internal:host-gateway --rm "owncloud/cdperf-k6" k6 run "${k6_params[@]}" "$(basename "$t")"
       else
         # shellcheck disable=SC2068
         k6 run ${k6_params[@]} "$t"


### PR DESCRIPTION
Right now the output of the k6 docker container looks like:

```
running (0h00m01.0s), 3/3 VUs, 0 complete and 0 interrupted iterations
default   [   0% ] 3 VUs  0h00m00.9s/1h0m0s  0/3 shared iters

running (0h00m02.0s), 3/3 VUs, 0 complete and 0 interrupted iterations
default   [   0% ] 3 VUs  0h00m01.9s/1h0m0s  0/3 shared iters

...
```

so you get an update line all the time as the terminal is not able to refresh the former content. If k6 is run via an interactive terminal, you only get a self updating output:

```
running (0h00m05.7s), 3/3 VUs, 0 complete and 0 interrupted iterations
default   [--------------------------------------] 3 VUs  0h00m05.6s/1h0m0s  0/3 shared iters
```

This PR changes the docker execution of k6 to an interactive terminal.