### PR TITLE
allow cloud docker setup and teardown scripts

### DIFF
--- a/scripts/cdperf
+++ b/scripts/cdperf
@@ -273,13 +273,20 @@ done
 [[ ! $k6_test_host ]] && echo "Error: k6_test_host not set. --cloud-host=https://host.docker.internal:9200" && exit 1
 
 cloud_docker_env=()
+cloud_docker_volumes=()
+cloud_docker_setup_script=""
+cloud_docker_teardown_script=""
 
 if [[ $cloud_vendor == "ocis" ]]
 then
   [[ ! $cloud_docker_image ]] && cloud_docker_image="owncloud/ocis"
   [[ ! $cloud_docker_publish ]] && cloud_docker_publish="9200:9200"
   [[ $cloud_oidc != true ]] && cloud_docker_env+=("PROXY_ENABLE_BASIC_AUTH=true")
+  config_volume_name="ocis-config-k6"
   cloud_docker_env+=("OCIS_INSECURE=true")
+  cloud_docker_volumes+=("$config_volume_name:/etc/ocis")
+  cloud_docker_setup_script="docker run -e IDM_ADMIN_PASSWORD=admin --rm -it -v $config_volume_name:/etc/ocis owncloud/ocis init --insecure true"
+  cloud_docker_teardown_script="docker volume rm $config_volume_name"
 elif [[ $cloud_vendor == "oc10" ]]
 then
   [[ ! $cloud_docker_image ]] && cloud_docker_image="owncloud/server"
@@ -312,6 +319,10 @@ function cloud_stop() {
   # stop old container
   cloud_container=$(docker ps -q --filter ancestor=$cloud_docker_image)
   [[ $cloud_container ]] && docker stop "$cloud_container"
+  if [ -n "$cloud_docker_teardown_script" ]
+  then
+    $cloud_docker_teardown_script
+  fi
 }
 
 function cloud_start() {
@@ -322,9 +333,18 @@ function cloud_start() {
   do
     cloud_docker_env[$i]="--env ${cloud_docker_env[$i]}"
   done
+
+    for i in "${!cloud_docker_volumes[@]}"
+    do
+      cloud_docker_volumes[$i]="-v ${cloud_docker_volumes[$i]}"
+    done
   # start new container
   # shellcheck disable=SC2068
-  docker run ${cloud_docker_env[@]} --rm --detach --pull always --publish $cloud_docker_publish $cloud_docker_image
+  if [ -n "$cloud_docker_setup_script" ]
+  then
+    $cloud_docker_setup_script
+  fi
+  docker run ${cloud_docker_env[@]} --rm --detach --pull always ${cloud_docker_volumes[@]} --publish $cloud_docker_publish $cloud_docker_image
 }
 
 function k6_run(){


### PR DESCRIPTION
ocis needs to be initialized these days (see https://owncloud.dev/ocis/getting-started/#docker)
this PR allows to have some setup and teardown commands to be able to create the ocis config and to delete it
