### PR TITLE
fix link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -34,7 +34,7 @@ const sidebarK6Tests = () => {
         items: [
           {text: '- Welcome', link: '/k6-tests/docs/'},
           {text: '- Considerations', link: '/k6-tests/docs/considerations'},
-          {text: '- Hot to run', link: '/k6-tests/docs/run'},
+          {text: '- How to run', link: '/k6-tests/docs/run'},
         ]
       },
       {

--- a/packages/k6-tests/README.md
+++ b/packages/k6-tests/README.md
@@ -2,7 +2,7 @@
 This repository contains the tools we use to test and measure the performance of different cloud systems.
 
 ## Usage
-Please read the [how to run](https://owncloud.dev/cdperf/run/) section.
+Please read the [how to run](https://owncloud.dev/cdperf/k6-tests/docs/run) section.
 
 ## How to test
 It's important to know how to compare the tests against each other and what those numbers mean.


### PR DESCRIPTION
- corrected link

<img width="867" alt="image" src="https://github.com/owncloud/cdperf/assets/84779829/73130aca-1d92-42f6-86fa-dc0583e33d1e">

- and typo

<img width="257" alt="Screenshot 2023-07-05 at 16 40 27" src="https://github.com/owncloud/cdperf/assets/84779829/1599e43c-6e68-42d6-8d7e-2820eaa7abad">
