### PR TITLE
[OCISDEV-802] Bug: Create LDAP load test

### DIFF
--- a/packages/k6-tdk/src/client/group.ts
+++ b/packages/k6-tdk/src/client/group.ts
@@ -72,6 +72,28 @@ export class Group extends EndpointClient {
     return response
   }
 
+  addUsersToGroup(p: { groupIdOrName: string, userIds: string[], baseUrl: string }): RefinedResponse<'text' | 'none'> {
+    let response: RefinedResponse<'text' | 'none'>
+    let expectedStatus: number
+    switch (this.platform) {
+      case Platform.ownCloudServer:
+      case Platform.nextcloud:
+        throw new Error('addUsersToGroup is not supported on this platform')
+      case Platform.ownCloudInfiniteScale:
+      default:
+        response = endpoints.graph.v1.groups.PATCH__add_users_to_group(this.httpClient, { groupId: p.groupIdOrName, userIds: p.userIds, baseUrl: p.baseUrl })
+        expectedStatus = 204
+    }
+
+    check({ val: response }, {
+      'client -> group.addUsersToGroup - status': ({ status }) => {
+        return status === expectedStatus
+      }
+    })
+
+    return response
+  }
+
   addUserToGroup(p: { groupIdOrName: string, userIdOrLogin: string, baseUrl?: string }): RefinedResponse<'text' | 'none'> {
     let response: RefinedResponse<'text' | 'none'>
     let expectedStatus: number

--- a/packages/k6-tdk/src/client/group.ts
+++ b/packages/k6-tdk/src/client/group.ts
@@ -73,17 +73,9 @@ export class Group extends EndpointClient {
   }
 
   addUsersToGroup(p: { groupIdOrName: string, userIds: string[], baseUrl: string }): RefinedResponse<'text' | 'none'> {
-    let response: RefinedResponse<'text' | 'none'>
-    let expectedStatus: number
-    switch (this.platform) {
-      case Platform.ownCloudServer:
-      case Platform.nextcloud:
-        throw new Error('addUsersToGroup is not supported on this platform')
-      case Platform.ownCloudInfiniteScale:
-      default:
-        response = endpoints.graph.v1.groups.PATCH__add_users_to_group(this.httpClient, { groupId: p.groupIdOrName, userIds: p.userIds, baseUrl: p.baseUrl })
-        expectedStatus = 204
-    }
+    
+    const response: RefinedResponse<'text' | 'none'> = endpoints.graph.v1.groups.PATCH__add_users_to_group(this.httpClient, { groupId: p.groupIdOrName, userIds: p.userIds, baseUrl: p.baseUrl })
+    const expectedStatus: number = 204
 
     check({ val: response }, {
       'client -> group.addUsersToGroup - status': ({ status }) => {

--- a/packages/k6-tdk/src/client/user.ts
+++ b/packages/k6-tdk/src/client/user.ts
@@ -7,6 +7,26 @@ import { Platform } from '@/values'
 import { EndpointClient } from './client'
 
 export class User extends EndpointClient {
+  getUsers(): RefinedResponse<'text'> | undefined {
+    let response: RefinedResponse<'text'> | undefined
+    switch (this.platform) {
+      case Platform.ownCloudServer:
+      case Platform.nextcloud:
+        break
+      case Platform.ownCloudInfiniteScale:
+      default:
+        response = endpoints.graph.v1.users.GET__get_users(this.httpClient, {})
+    }
+
+    check({ skip: !response, val: response }, {
+      'client -> user.getUsers - status': (r) => {
+        return r?.status === 200
+      }
+    })
+
+    return response
+  }
+
   getUser(p: { userLogin: string }): RefinedResponse<'text'> | undefined {
     let response: RefinedResponse<'text'> | undefined
     switch (this.platform) {

--- a/packages/k6-tdk/src/client/user.ts
+++ b/packages/k6-tdk/src/client/user.ts
@@ -8,15 +8,8 @@ import { EndpointClient } from './client'
 
 export class User extends EndpointClient {
   getUsers(): RefinedResponse<'text'> | undefined {
-    let response: RefinedResponse<'text'> | undefined
-    switch (this.platform) {
-      case Platform.ownCloudServer:
-      case Platform.nextcloud:
-        break
-      case Platform.ownCloudInfiniteScale:
-      default:
-        response = endpoints.graph.v1.users.GET__get_users(this.httpClient, {})
-    }
+    
+    const response: RefinedResponse<'text'> | undefined = endpoints.graph.v1.users.GET__get_users(this.httpClient, {})
 
     check({ skip: !response, val: response }, {
       'client -> user.getUsers - status': (r) => {
@@ -28,16 +21,9 @@ export class User extends EndpointClient {
   }
 
   getUser(p: { userLogin: string }): RefinedResponse<'text'> | undefined {
-    let response: RefinedResponse<'text'> | undefined
-    switch (this.platform) {
-      case Platform.ownCloudServer:
-      case Platform.nextcloud:
-        break
-      case Platform.ownCloudInfiniteScale:
-      default:
-        response = endpoints.graph.v1.users.GET__get_user(this.httpClient, p)
-    }
-
+    
+    const response: RefinedResponse<'text'> | undefined = endpoints.graph.v1.users.GET__get_user(this.httpClient, p)
+    
     check({ skip: !response, val: response }, {
       'client -> user.getUser - status': (r) => {
         return r?.status === 200

--- a/packages/k6-tdk/src/endpoints/graph-v1-groups.ts
+++ b/packages/k6-tdk/src/endpoints/graph-v1-groups.ts
@@ -20,6 +20,12 @@ export const POST__add_user_to_group: Endpoint<{ groupId: string, userId: string
   }))
 }
 
+export const PATCH__add_users_to_group: Endpoint<{ groupId: string, userIds: string[], baseUrl: string }, 'none'> = (httpClient, { groupId, userIds, baseUrl }) => {
+  return httpClient('PATCH', `/graph/v1.0/groups/${groupId}`, JSON.stringify({
+    'members@odata.bind': userIds.map((userId) => `${baseUrl}/graph/v1.0/users/${userId}`)
+  }))
+}
+
 export const DELETE__remove_user_from_group: Endpoint<{ groupId: string, userId: string }, 'none'> = (httpClient, { groupId, userId }) => {
   return httpClient('DELETE', `/graph/v1.0/groups/${groupId}/members/${userId}/$ref`)
 }

--- a/packages/k6-tdk/src/endpoints/graph-v1-users.ts
+++ b/packages/k6-tdk/src/endpoints/graph-v1-users.ts
@@ -1,5 +1,9 @@
 import { Endpoint } from './endpoints'
 
+export const GET__get_users: Endpoint<{}, 'text'> = (httpClient) => {
+  return httpClient('GET', '/graph/v1.0/users')
+}
+
 export const GET__get_user: Endpoint<{ userLogin: string }, 'text'> = (httpClient, { userLogin }) => {
   return httpClient('GET', `/graph/v1.0/users/${userLogin}`)
 }

--- a/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
+++ b/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
@@ -1,4 +1,4 @@
-import { queryJson } from '@ownclouders/k6-tdk/lib/utils'
+import { ENV, queryJson } from '@ownclouders/k6-tdk/lib/utils'
 import { sleep } from 'k6'
 import exec from 'k6/execution'
 import { Options } from 'k6/options'
@@ -13,7 +13,10 @@ export const options: Options = {
 }
 
 const settings = {
-  ...envValues()
+  ...envValues(),
+  get usersCountPerGroup() {
+    return parseInt(ENV('USERS_COUNT_PER_GROUP', '0'), 10)
+  }
 }
 
 export const ldap_create_group_add_users_and_delete_group_130 = async (): Promise<void> => {
@@ -21,9 +24,17 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
   const adminClient = clientFor({ userLogin: settings.admin.login, userPassword: settings.admin.password })
 
   const getUsersResponse = adminClient.user.getUsers()
-  const addedUsers = new Set<string>(
-    queryJson('$.value[*].id', getUsersResponse?.body).filter(Boolean)
-  )
+  let userIds: string[] = queryJson('$.value[*].id', getUsersResponse?.body).filter(Boolean)
+
+  if (settings.usersCountPerGroup > 0) {
+    for (let i = userIds.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [userIds[i], userIds[j]] = [userIds[j], userIds[i]]
+    }
+    userIds = userIds.slice(0, settings.usersCountPerGroup)
+  }
+
+  const addedUsers = new Set<string>(userIds)
 
   sleep(settings.sleep.after_request)
 

--- a/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
+++ b/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
@@ -26,13 +26,15 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
   const getUsersResponse = adminClient.user.getUsers()
   let userIds: string[] = queryJson('$.value[*].id', getUsersResponse?.body).filter(Boolean)
 
-  if (settings.usersCountPerGroup > 0) {
-    for (let i = userIds.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [userIds[i], userIds[j]] = [userIds[j], userIds[i]]
-    }
-    userIds = userIds.slice(0, settings.usersCountPerGroup)
+  if (settings.usersCountPerGroup <= 0) {
+    throw new Error('USERS_COUNT_PER_GROUP must be greater than 0')
   }
+
+  for (let i = userIds.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [userIds[i], userIds[j]] = [userIds[j], userIds[i]]
+  }
+  userIds = userIds.slice(0, settings.usersCountPerGroup)
 
   const addedUsers = new Set<string>(userIds)
 

--- a/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
+++ b/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
@@ -3,9 +3,7 @@ import { sleep } from 'k6'
 import exec from 'k6/execution'
 import { Options } from 'k6/options'
 
-import { userPool } from '@/pools'
 import { clientFor } from '@/shortcuts'
-import { getPoolItems } from '@/utils'
 import { envValues } from '@/values'
 
 export const options: Options = {
@@ -19,22 +17,15 @@ const settings = {
 }
 
 export const ldap_create_group_add_users_and_delete_group_130 = async (): Promise<void> => {
-  // Step 1: Login Admin user and resolve pool user UUIDs
+  // Step 1: Login Admin user and load existing users
   const adminClient = clientFor({ userLogin: settings.admin.login, userPassword: settings.admin.password })
 
-  const addedUsers = new Set<string>()
-  const poolUsers = getPoolItems({ pool: userPool, n: options.vus || 1 })
+  const getUsersResponse = adminClient.user.getUsers()
+  const addedUsers = new Set<string>(
+    queryJson('$.value[*].id', getUsersResponse?.body).filter(Boolean)
+  )
 
-  for (const poolUser of poolUsers) {
-    const getUserResponse = adminClient.user.getUser({ userLogin: poolUser.userLogin })
-    const [targetUserId] = queryJson('$.id', getUserResponse?.body)
-
-    if (targetUserId) {
-      addedUsers.add(targetUserId)
-    }
-
-    sleep(settings.sleep.after_request)
-  }
+  sleep(settings.sleep.after_request)
 
   // Step 2: Admin creates a test group
   const groupName = `k6-test-group-${exec.vu.idInTest}-${exec.scenario.iterationInTest}-${Date.now()}`

--- a/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
+++ b/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
@@ -22,16 +22,20 @@ const settings = {
 }
 
 export const ldap_create_group_add_users_and_delete_group_130 = async (): Promise<void> => {
-  // Step 1: Login Admin user and load existing users
+  
+  // Step 1: Login Admin user
   const adminClient = clientFor({ userLogin: settings.admin.login, userPassword: settings.admin.password })
 
+  // Step 2: Load all of existing users
   const getUsersResponse = adminClient.user.getUsers()
   let userIds: string[] = queryJson('$.value[*].id', getUsersResponse?.body).filter(Boolean)
 
+  // Guard USERS_COUNT_PER_GROUP > 0
   if (settings.usersCountPerGroup <= 0) {
     throw new Error('USERS_COUNT_PER_GROUP must be greater than 0')
   }
 
+  // Preparing USERS_COUNT_PER_GROUP randomly from the list
   for (let i = userIds.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [userIds[i], userIds[j]] = [userIds[j], userIds[i]]
@@ -40,7 +44,7 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
 
   sleep(settings.sleep.after_request)
 
-  // Step 2: Admin creates a test group
+  // Step 3: Admin creates a test group
   const groupName = `k6-test-group-${exec.vu.idInTest}-${exec.scenario.iterationInTest}-${Date.now()}`
   const createGroupResponse = adminClient.group.createGroup({ groupName })
   const [groupId] = queryJson('$.id', createGroupResponse.body)
@@ -48,7 +52,7 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
 
   sleep(settings.sleep.after_request)
 
-  // Step 3: Add users to the group in batches
+  // Step 4: Add randomly selected users to the group in batches
   for (let i = 0; i < userIds.length; i += GRAPH_GROUP_MEMBERS_PATCH_LIMIT) {
     const chunk = userIds.slice(i, i + GRAPH_GROUP_MEMBERS_PATCH_LIMIT)
     adminClient.group.addUsersToGroup({
@@ -60,7 +64,7 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
     sleep(settings.sleep.after_request)
   }
 
-  // Step 4: Admin deletes the group
+  // Step 5: Admin deletes the group
   adminClient.group.deleteGroup({ groupIdOrName })
 
   sleep(settings.sleep.after_iteration)

--- a/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
+++ b/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.k6.ts
@@ -12,6 +12,8 @@ export const options: Options = {
   insecureSkipTLSVerify: true
 }
 
+const GRAPH_GROUP_MEMBERS_PATCH_LIMIT = 20
+
 const settings = {
   ...envValues(),
   get usersCountPerGroup() {
@@ -36,8 +38,6 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
   }
   userIds = userIds.slice(0, settings.usersCountPerGroup)
 
-  const addedUsers = new Set<string>(userIds)
-
   sleep(settings.sleep.after_request)
 
   // Step 2: Admin creates a test group
@@ -48,11 +48,12 @@ export const ldap_create_group_add_users_and_delete_group_130 = async (): Promis
 
   sleep(settings.sleep.after_request)
 
-  // Step 3: Add each resolved user to the group
-  for (const userId of addedUsers) {
-    adminClient.group.addUserToGroup({
+  // Step 3: Add users to the group in batches
+  for (let i = 0; i < userIds.length; i += GRAPH_GROUP_MEMBERS_PATCH_LIMIT) {
+    const chunk = userIds.slice(i, i + GRAPH_GROUP_MEMBERS_PATCH_LIMIT)
+    adminClient.group.addUsersToGroup({
       groupIdOrName,
-      userIdOrLogin: userId,
+      userIds: chunk,
       baseUrl: settings.platform.base_url
     })
 

--- a/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.md
+++ b/packages/k6-tests/tests/koko/platform/130-ldap-create-group-add-users-and-delete-group/simple.md
@@ -7,7 +7,7 @@ The `130 LDAP create group add users and delete group` test simulates LDAP write
 
 * the `admin` user logs into the system.
 * each `iteration` performs the following steps:
-  1. **Login Admin & Resolve User UUIDs** - Authenticate as admin and resolve pool user UUIDs via Graph API
+  1. **Login Admin & Load Existing Users** - Authenticate as admin and load all existing users via Graph API
   2. **Create Group** - Admin creates a new test group with a unique name
   3. **Add Users to Group** - Admin adds each resolved user to the created group
   4. **Delete Group** - Admin removes the group from the system


### PR DESCRIPTION
# Issue

JIRA: [OCISDEV-802](https://kiteworks.atlassian.net/browse/OCISDEV-802)
---

# Code abstract

- fix bug in koko `130-ldap-create-group-add-users-and-delete-group` test and docs

# Test abstract

* the `admin` user logs into the system.
* each `iteration` performs the following steps:
  1. **Login Admin & Resolve User UUIDs** - Authenticate as admin and resolve pool user UUIDs via Graph API
  2. **Create Group** - Admin creates a new test group with a unique name
  3. **Add Users to Group** - Admin adds each resolved user to the created group
  4. **Delete Group** - Admin removes the group from the system

# How to run the test locally

## 1. Checkout the oCIS repository from [here](https://github.com/owncloud/ocis).
```bash
# get the source
git clone git@github.com:owncloud/ocis.git
```
## 2. Run a local instance of oCIS - [Run ownCloud Infinite Scale](https://github.com/owncloud/ocis?tab=readme-ov-file#use-the-official-documentation)
```bash
# generate assets
make generate

# build the binary
make -C ocis build

# initialize a minimal oCIS configuration
IDM_ADMIN_PASSWORD=admin ./ocis/bin/ocis init --force-overwrite
```

## 3. Build `ociswrapper`
```bash
# enter the ocis dir
cd tests/ociswrapper

# build the binary
make
```

## 4. Run the `ociswrapper`
```bash
# running the ociswrapper
IDM_ADMIN_PASSWORD=admin \
PROXY_ENABLE_BASIC_AUTH=true \
OCIS_ADD_RUN_SERVICES=notifications \
NOTIFICATIONS_SMTP_HOST=localhost \
NOTIFICATIONS_SMTP_PORT=1025 \
NOTIFICATIONS_SMTP_INSECURE=true \
NOTIFICATIONS_SMTP_SENDER="owncloud <noreply@example.com>" \
./bin/ociswrapper serve --bin=../../ocis/bin/ocis
```

## 5. Install Grafana k6 framework
Follow the steps given [here](https://grafana.com/docs/k6/latest/get-started/running-k6/)

## 6. Build `cdPerf`
```bash
# install pnpm
pnpm install

# building
pnpm build
```

## 7. Run the `130-ldap-create-group-add-users-and-delete-group` test
```bash
ADMIN_LOGIN=admin \
ADMIN_PASSWORD=admin \
USERS_COUNT_PER_GROUP=50 \
PLATFORM_BASE_URL=https://ocis.owncloud.test \
AUTH_N_PROVIDER_KOPANO_BASE_URL=https://ocis.owncloud.test \
AUTH_N_PROVIDER_KOPANO_REDIRECT_URL=https://ocis.owncloud.test/oidc-callback.html \
k6 run packages/k6-tests/artifacts/koko-platform-130-ldap-create-group-add-users-and-delete-group-simple-k6.js  --vus 5 --iterations 25
```

# Sources

- Run [ownCloud Infinite Scale](https://grafana.com/docs/k6/latest/get-started/running-k6/) 
- cdPerf - [guide how to run the tests](https://owncloud.dev/cdperf/k6-tests/docs/run)
- Grafana - [running k6](https://grafana.com/docs/k6/latest/get-started/running-k6/)
- ociswrapper - [run oCIS with `ociswrapper`](https://owncloud.dev/ocis/development/testing/#run-ocis-with-ociswrapper)